### PR TITLE
Logic for set vs del

### DIFF
--- a/napalm_opengear/opengear.py
+++ b/napalm_opengear/opengear.py
@@ -125,9 +125,12 @@ class OpenGearDriver(NetworkDriver):
 
         candidate = ["=".join(line.split(" ", 1)) for line in candidate if line]
         for command in candidate:
-            if 'sudo config -s' not in command:
-                command = 'sudo config -s {0}'.format(command)
-                print(command)
+            if '=' not in command:  # assignment via `=` means set a vaule
+                command = 'sudo config -d "{0}"'.format(command.strip())
+                # print(command)
+            else:  # no assignment, means delete the value
+                command = 'sudo config -s "{0}"'.format(command.strip())
+                # print(command)
             output = self._send_command(command)
             if "error" in output or "not found" in output:
                 raise MergeConfigException("Command '{0}' cannot be applied.".format(command))


### PR DESCRIPTION
If there is a space in the config, then convert the first space to a `=` and `config -s foo=bar`.

Else, if there is no space, and ergo no `=`, then the command is a deletion: `config -d foo`

Closes https://github.com/yeled/napalm-opengear/issues/15

It'd be good to have tests. There are none